### PR TITLE
allowed custom recipient in notification

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "guzzlehttp/guzzle": "^6.5",
         "illuminate/support": "^6.0|^7.0",
         "illuminate/notifications": "^6.0|^7.0",
-        "nesbot/carbon": "^2.31",
+        "nesbot/carbon": "^2.0",
         "ext-simplexml": "*"
     },
     "require-dev": {

--- a/src/NetgsmChannel.php
+++ b/src/NetgsmChannel.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Notifications\Notification;
 use TarfinLabs\Netgsm\Exceptions\IncorrectPhoneNumberFormatException;
 use TarfinLabs\Netgsm\Sms\AbstractNetgsmMessage;
+use TarfinLabs\Netgsm\Sms\NetgsmSmsMessage;
 
 class NetgsmChannel
 {
@@ -20,8 +21,8 @@ class NetgsmChannel
     /**
      * Send the given notification.
      *
-     * @param $notifiable
-     * @param  Notification  $notification
+     * @param              $notifiable
+     * @param Notification $notification
      * @throws Exceptions\CouldNotSendNotification
      * @throws GuzzleException
      * @throws IncorrectPhoneNumberFormatException
@@ -30,13 +31,18 @@ class NetgsmChannel
     {
         $message = $notification->toNetgsm($notifiable);
 
-        if (! $message instanceof AbstractNetgsmMessage) {
+        if (is_string($message)) {
+            $message = new NetgsmSmsMessage($message);
+        }
+
+        if (!$message instanceof AbstractNetgsmMessage) {
             throw new Exception('Geçerli bir Netgsm mesajı değil');
         }
 
-        $phone = $notifiable->routeNotificationFor('Netgsm');
-
-        $message->setRecipients($phone);
+        if (!$message->getRecipients()) {
+            $phone = $notifiable->routeNotificationFor('Netgsm');
+            $message->setRecipients($phone);
+        }
 
         $this->netgsm->sendSms($message);
     }

--- a/src/NetgsmChannel.php
+++ b/src/NetgsmChannel.php
@@ -31,10 +31,6 @@ class NetgsmChannel
     {
         $message = $notification->toNetgsm($notifiable);
 
-        if (is_string($message)) {
-            $message = new NetgsmSmsMessage($message);
-        }
-
         if (! $message instanceof AbstractNetgsmMessage) {
             throw new Exception('Geçerli bir Netgsm mesajı değil');
         }

--- a/src/NetgsmChannel.php
+++ b/src/NetgsmChannel.php
@@ -35,11 +35,11 @@ class NetgsmChannel
             $message = new NetgsmSmsMessage($message);
         }
 
-        if (!$message instanceof AbstractNetgsmMessage) {
+        if (! $message instanceof AbstractNetgsmMessage) {
             throw new Exception('Geçerli bir Netgsm mesajı değil');
         }
 
-        if (!$message->getRecipients()) {
+        if (! $message->getRecipients()) {
             $phone = $notifiable->routeNotificationFor('Netgsm');
             $message->setRecipients($phone);
         }

--- a/src/NetgsmChannel.php
+++ b/src/NetgsmChannel.php
@@ -7,7 +7,6 @@ use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Notifications\Notification;
 use TarfinLabs\Netgsm\Exceptions\IncorrectPhoneNumberFormatException;
 use TarfinLabs\Netgsm\Sms\AbstractNetgsmMessage;
-use TarfinLabs\Netgsm\Sms\NetgsmSmsMessage;
 
 class NetgsmChannel
 {


### PR DESCRIPTION
It overrides recipients without checking existence.
in this case we lost the $customNumber in channel file
	public function toNetgsm($notifiable)
	{
....
		return (new NetGsmOtpMessage($message))
			->setRecipients([$customNumber]);
	}