### PR TITLE
Laravel 12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,46 +1,41 @@
 name: tests
 
-on: [push, pull_request]
+on:
+    push:
+      branches:
+        - master
+        - '*.x'
+    pull_request:
 
 jobs:
     test:
-
         runs-on: ubuntu-latest
+
         strategy:
             fail-fast: true
             matrix:
-                php: [7.4, '8.0', 8.1, 8.2, 8.3]
-                laravel: [8, 9, 10, 11]
-                exclude:
-                    - php: 7.4
-                      laravel: 9
-                    - php: 7.4
-                      laravel: 10
-                    - php: 7.4
-                      laravel: 11  
-                    - php: '8.0'
-                      laravel: 10
-                    - php: '8.0'
-                      laravel: 11
-                    - php: 8.1
-                      laravel: 11
-                    - php: 8.2
-                      laravel: 8
+                php: [8.2, 8.3, 8.4]
+                laravel: [11, 12]
+                stability: [prefer-lowest, prefer-stable]
 
-        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+        name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Stability ${{ matrix.stability }}
 
         steps:
-            -   name: Checkout the code
-                uses: actions/checkout@v2
+            - name: Checkout code
+              uses: actions/checkout@v4
 
-            -   name: Setup PHP
-                uses: shivammathur/setup-php@v2
-                with:
-                    php-version: ${{ matrix.php }}
-                    extensions: simplexml
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+                  extensions: dom, curl, libxml, mbstring, zip
+                  ini-values: error_reporting=E_ALL
+                  tools: composer:v2
+                  coverage: none
 
-            -   name: Install dependencies
-                run: composer install --no-progress --no-ansi --profile --no-interaction --no-scripts --prefer-dist
+            - name: Install dependencies
+              run: |
+                  composer update --prefer-dist --no-interaction --no-progress --${{ matrix.stability }}
 
-            -   name: Execute tests
-                run: vendor/bin/phpunit --testdox --colors=always --exclude-group skipped
+            - name: Execute tests
+              run: vendor/bin/phpunit --testdox --colors=always --exclude-group skipped

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 /.idea
 /phpunit.xml
 .phpunit.result.cache
+.phpunit.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to `netgsm` will be documented in this file
 - Laravel 12 support added.
 - PHP 8.4 support added.
 - Laravel 10 and below versions are no longer supported.
-- PHP 8.2 and below versions are no longer supported.
+- PHP 8.1 and below versions are no longer supported.
 
 ## [4.6.0] - 2024-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `netgsm` will be documented in this file
 
 ## Unreleased
 
+## [5.0.0] - 2025-02-20
+- Laravel 12 support added.
+- PHP 8.4 support added.
+- Laravel 10 and below versions are no longer supported.
+- PHP 8.2 and below versions are no longer supported.
+
 ## [4.6.0] - 2024-04-08
 
 - Laravel 11 and PHP 8.3 support added.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 With this package, you can send easily [Netgsm notifications](https://www.netgsm.com.tr/dokuman/#api-dok%C3%BCman%C4%B1) with Laravel `^8.0`.
 This package also provides some simple reporting.
 
-> This package requires PHP `7.3` or higher and Laravel `8.0` or higher.   
-> For older versions of Laravel, please use version `^2.0.0` of this package!   
+> This package requires PHP `8.2` or higher and Laravel `11.0` or higher.   
+> For older versions of Laravel, please use version `^4.0.0` of this package!   
 
 ## Contents
 

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "illuminate/support": "^11.0|^12.0",
         "illuminate/notifications": "^11.0|^12.0",
         "illuminate/translation": "^11.0|^12.0",
-        "nesbot/carbon": "^2.0",
+        "nesbot/carbon": "^3.8.5",
         "ext-simplexml": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -31,19 +31,19 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0|^8.1|^8.2|^8.3",
+        "php": "^8.2|^8.3|^8.4",
         "guzzlehttp/guzzle": "^7.1",
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
-        "illuminate/notifications": "^8.0|^9.0|^10.0|^11.0",
-        "illuminate/translation": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^11.0|^12.0",
+        "illuminate/notifications": "^11.0|^12.0",
+        "illuminate/translation": "^11.0|^12.0",
         "nesbot/carbon": "^2.0",
         "ext-simplexml": "*"
     },
     "require-dev": {
         "fakerphp/faker": "^1.14",
-        "phpunit/phpunit": "^9.4",
+        "phpunit/phpunit": "^10.0|^11.0",
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0"
+        "orchestra/testbench": "^9.0|^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-    <report>
-      <clover outputFile="build/logs/clover.xml"/>
-      <html outputDirectory="build/coverage"/>
-      <text outputFile="build/coverage.txt"/>
-    </report>
-  </coverage>
-  <testsuites>
-    <testsuite name="Test Suite">
-      <directory>tests</directory>
-    </testsuite>
-  </testsuites>
-  <logging>
-    <junit outputFile="build/report.junit.xml"/>
-  </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/Report/NetgsmSmsDetailReport.php
+++ b/src/Report/NetgsmSmsDetailReport.php
@@ -92,7 +92,7 @@ class NetgsmSmsDetailReport extends AbstractNetgsmReport
     public function parseResponse(string $response): Collection
     {
         $this->validateResponse($response);
-        $response = utf8_encode(html_entity_decode($response));
+        $response = mb_convert_encoding(html_entity_decode($response), 'UTF-8', 'ISO-8859-9');
         $xml = new SimpleXMLElement($response);
 
         $collection = new Collection();

--- a/tests/NetGsmChannelTest.php
+++ b/tests/NetGsmChannelTest.php
@@ -4,6 +4,7 @@ namespace TarfinLabs\Netgsm\Tests;
 
 use GuzzleHttp\Client;
 use Mockery;
+use PHPUnit\Framework\Attributes\Test;
 use TarfinLabs\Netgsm\Netgsm;
 use TarfinLabs\Netgsm\NetgsmChannel;
 use TarfinLabs\Netgsm\Tests\notification\TestNotifiable;
@@ -50,7 +51,7 @@ class NetGsmChannelTest extends BaseTestCase
         $this->channel = new NetGsmChannel($this->netgsm);
     }
 
-    /** @test */
+    #[Test]
     public function test_it_shares_message(): void
     {
         $this->netgsm->shouldReceive('sendSms')->once();

--- a/tests/NetGsmIysTest.php
+++ b/tests/NetGsmIysTest.php
@@ -5,6 +5,7 @@ namespace TarfinLabs\Netgsm\Tests;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
 use Mockery;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\ResponseInterface;
 use TarfinLabs\Netgsm\Iys\Requests\Add;
 use TarfinLabs\Netgsm\Iys\Requests\Search;
@@ -32,7 +33,7 @@ class NetGsmIysTest extends BaseTestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_makes_add_requests_for_iys_addresses()
     {
         $data = [
@@ -100,7 +101,7 @@ class NetGsmIysTest extends BaseTestCase
         $this->assertEquals('73113cb9-dff0-415b-9491-xxxxxxxxxx', $decodedResponse['uid']);
     }
 
-    /** @test */
+    #[Test]
     public function it_makes_search_requests_for_iys_addresses()
     {
         $data = [

--- a/tests/NetGsmIysTest.php
+++ b/tests/NetGsmIysTest.php
@@ -80,13 +80,24 @@ class NetGsmIysTest extends BaseTestCase
         $iysAddress = new Add();
         $iysAddress->setDefaults($data['json']['body']['data'][0]);
 
+        $successResponse = [
+            'code' => '0',
+            'error' => 'false',
+            'uid' => '73113cb9-dff0-415b-9491-xxxxxxxxxx'
+        ];
+
         $this->httpClient
             ->shouldReceive('request')
             ->withSomeOfArgs('POST', 'iys/add', $data)
             ->once()
-            ->andReturn(new Response());
+            ->andReturn(new Response(200, [], json_encode($successResponse)));
 
-        $this->netgsm->iys()->addAddress($iysAddress)->send();
+        $response = $this->netgsm->iys()->addAddress($iysAddress)->send();
+        $decodedResponse = json_decode($response, true);
+
+        $this->assertEquals('0', $decodedResponse['code']);
+        $this->assertEquals('false', $decodedResponse['error']);
+        $this->assertEquals('73113cb9-dff0-415b-9491-xxxxxxxxxx', $decodedResponse['uid']);
     }
 
     /** @test */
@@ -118,12 +129,40 @@ class NetGsmIysTest extends BaseTestCase
         $iysSearch = new Search();
         $iysSearch->setDefaults($data['json']['body']['data'][0]);
 
+        $searchResponse = [
+            'code' => '0',
+            'error' => 'false',
+            'query' => [
+                'consentDate' => '2020-11-06 11:22:34',
+                'source' => 'HS_FIZIKSEL_ORTAM',
+                'recipient' => '+905XXXXXXXXX',
+                'recipientType' => 'BIREYSEL',
+                'type' => 'MESAJ',
+                'status' => 'ONAY',
+                'creationDate' => '2020-11-06 11:23:49',
+                'retailerAccessCount' => 0
+            ]
+        ];
+
         $this->httpClient
             ->shouldReceive('request')
             ->withSomeOfArgs('POST', 'iys/search', $data)
             ->once()
-            ->andReturn(new Response());
+            ->andReturn(new Response(200, [], json_encode($searchResponse)));
 
-        $this->netgsm->iys()->searchAddress($iysSearch)->send();
+        $response = $this->netgsm->iys()->searchAddress($iysSearch)->send();
+        $decodedResponse = json_decode($response, true);
+
+        $this->assertEquals('0', $decodedResponse['code']);
+        $this->assertEquals('false', $decodedResponse['error']);
+        $this->assertArrayHasKey('query', $decodedResponse);
+        $this->assertEquals('ONAY', $decodedResponse['query']['status']);
+        $this->assertEquals('MESAJ', $decodedResponse['query']['type']);
+        $this->assertEquals('HS_FIZIKSEL_ORTAM', $decodedResponse['query']['source']);
+        $this->assertEquals('BIREYSEL', $decodedResponse['query']['recipientType']);
+        $this->assertEquals('+905XXXXXXXXX', $decodedResponse['query']['recipient']);
+        $this->assertEquals('2020-11-06 11:22:34', $decodedResponse['query']['consentDate']);
+        $this->assertEquals('2020-11-06 11:23:49', $decodedResponse['query']['creationDate']);
+        $this->assertEquals(0, $decodedResponse['query']['retailerAccessCount']);
     }
 }

--- a/tests/NetGsmIysTest.php
+++ b/tests/NetGsmIysTest.php
@@ -84,7 +84,7 @@ class NetGsmIysTest extends BaseTestCase
         $successResponse = [
             'code' => '0',
             'error' => 'false',
-            'uid' => '73113cb9-dff0-415b-9491-xxxxxxxxxx'
+            'uid' => '73113cb9-dff0-415b-9491-xxxxxxxxxx',
         ];
 
         $this->httpClient
@@ -141,8 +141,8 @@ class NetGsmIysTest extends BaseTestCase
                 'type' => 'MESAJ',
                 'status' => 'ONAY',
                 'creationDate' => '2020-11-06 11:23:49',
-                'retailerAccessCount' => 0
-            ]
+                'retailerAccessCount' => 0,
+            ],
         ];
 
         $this->httpClient

--- a/tests/NetGsmMessageTest.php
+++ b/tests/NetGsmMessageTest.php
@@ -2,11 +2,12 @@
 
 namespace TarfinLabs\Netgsm\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use TarfinLabs\Netgsm\Sms\NetgsmSmsMessage;
 
 class NetGsmMessageTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function it_supports_create_method()
     {
         $content = $this->faker->sentence;
@@ -17,7 +18,7 @@ class NetGsmMessageTest extends BaseTestCase
         $this->assertEquals($content, $message->getMessage());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_body()
     {
         $content = $this->faker->sentence;
@@ -27,7 +28,7 @@ class NetGsmMessageTest extends BaseTestCase
         $this->assertEquals($content, $message->getMessage());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_header()
     {
         $name = $this->faker->company;
@@ -37,7 +38,7 @@ class NetGsmMessageTest extends BaseTestCase
         $this->assertEquals($name, $message->getHeader());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_send_method()
     {
         $method = $this->faker->randomElement(['xml', 'get']);
@@ -47,7 +48,7 @@ class NetGsmMessageTest extends BaseTestCase
         $this->assertEquals($method, $message->getSendMethod());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_needs_authorized_data()
     {
         $authorizedData = $this->faker->boolean;
@@ -57,7 +58,7 @@ class NetGsmMessageTest extends BaseTestCase
         $this->assertEquals($authorizedData, $message->isAuthorizedData());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_recipients_from_array()
     {
         $message = (new NetgsmSmsMessage)->setRecipients([31650520659, 31599858770]);
@@ -65,7 +66,7 @@ class NetGsmMessageTest extends BaseTestCase
         $this->assertEquals(['31650520659', '31599858770'], $message->getRecipients());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_recipients_from_integer()
     {
         $message = (new NetgsmSmsMessage)->setRecipients(31650520659);
@@ -73,7 +74,7 @@ class NetGsmMessageTest extends BaseTestCase
         $this->assertEquals([31650520659], $message->getRecipients());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_recipients_from_string()
     {
         $message = (new NetgsmSmsMessage)->setRecipients('31650520659');

--- a/tests/NetGsmReportDetailTest.php
+++ b/tests/NetGsmReportDetailTest.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Mockery;
+use PHPUnit\Framework\Attributes\Test;
 use SimpleXMLElement;
 use TarfinLabs\Netgsm\Exceptions\ReportException;
 use TarfinLabs\Netgsm\Netgsm;
@@ -171,9 +172,7 @@ class NetGsmReportDetailTest extends BaseTestCase
         return $report;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_does_get_same_row_count_with_correct_arguments()
     {
         $type = $this->faker->randomElement([0, 1]);
@@ -198,9 +197,7 @@ class NetGsmReportDetailTest extends BaseTestCase
         $this->assertSame($report->count(), $rowCount * $pages);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function should_throw_exception_when_return_code_is_not_success()
     {
         $version = $this->faker->randomElement([0, 1, 2, 3]);
@@ -226,9 +223,7 @@ class NetGsmReportDetailTest extends BaseTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function response_should_properly_parsed_according_by_version()
     {
         $version = $this->faker->randomElement([2]);

--- a/tests/NetGsmReportTest.php
+++ b/tests/NetGsmReportTest.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Mockery;
+use PHPUnit\Framework\Attributes\Test;
 use TarfinLabs\Netgsm\Exceptions\ReportException;
 use TarfinLabs\Netgsm\Netgsm;
 use TarfinLabs\Netgsm\Report\NetgsmSmsReport;
@@ -167,9 +168,7 @@ class NetGsmReportTest extends BaseTestCase
         return $report;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_does_get_same_row_count_with_correct_arguments()
     {
         $version = $this->faker->randomElement([0, 1, 2, 3]);
@@ -188,9 +187,7 @@ class NetGsmReportTest extends BaseTestCase
         $this->assertSame($report->count(), $rowCount);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function should_throw_exception_when_return_code_is_not_success()
     {
         $version = $this->faker->randomElement([0, 1, 2, 3]);
@@ -209,9 +206,7 @@ class NetGsmReportTest extends BaseTestCase
         ]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function response_should_properly_parsed_according_by_version()
     {
         $version = $this->faker->randomElement([2]);

--- a/tests/NetGsmTest.php
+++ b/tests/NetGsmTest.php
@@ -5,6 +5,7 @@ namespace TarfinLabs\Netgsm\Tests;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
 use Mockery;
+use PHPUnit\Framework\Attributes\Test;
 use TarfinLabs\Netgsm\Exceptions\CouldNotSendNotification;
 use TarfinLabs\Netgsm\Exceptions\IncorrectPhoneNumberFormatException;
 use TarfinLabs\Netgsm\Exceptions\NetgsmException;
@@ -51,9 +52,7 @@ class NetGsmTest extends BaseTestCase
         return $netgsmMessage;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_send_sms_message_with_correct_arguments()
     {
         $code = $this->faker->randomElement(['00', '01', '02']);
@@ -73,9 +72,7 @@ class NetGsmTest extends BaseTestCase
         $this->assertSame($jobId, $returnedJobId);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function should_throw_exception_when_return_code_is_not_success()
     {
         $this->expectException(CouldNotSendNotification::class);
@@ -90,9 +87,7 @@ class NetGsmTest extends BaseTestCase
         $this->netgsm->sendSms($this->newSmsMessage());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function should_throw_exception_when_is_no_job_id_in_response()
     {
         $this->expectException(NetgsmException::class);
@@ -107,9 +102,7 @@ class NetGsmTest extends BaseTestCase
         $this->netgsm->sendSms($this->newSmsMessage());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function should_throw_exception_when_phone_number_is_incorrect()
     {
         $this->expectException(IncorrectPhoneNumberFormatException::class);

--- a/tests/NetgsmAvailableCreditTest.php
+++ b/tests/NetgsmAvailableCreditTest.php
@@ -5,6 +5,7 @@ namespace TarfinLabs\Netgsm\Tests;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
 use Mockery;
+use PHPUnit\Framework\Attributes\Test;
 use TarfinLabs\Netgsm\Exceptions\NetgsmException;
 use TarfinLabs\Netgsm\Netgsm;
 
@@ -45,9 +46,7 @@ class NetgsmAvailableCreditTest extends BaseTestCase
             ));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_get_available_credit_balance_with_correct_arguments()
     {
         $credit = $this->faker->numberBetween(5, 10);
@@ -61,9 +60,7 @@ class NetgsmAvailableCreditTest extends BaseTestCase
         $this->assertSame((string) $credit, $response);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function should_throw_exception_when_return_code_is_not_success()
     {
         $errorCode = $this->faker->randomElement([30, 40, 100]);

--- a/tests/NetgsmAvailablePackagesTest.php
+++ b/tests/NetgsmAvailablePackagesTest.php
@@ -5,6 +5,7 @@ namespace TarfinLabs\Netgsm\Tests;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
 use Mockery;
+use PHPUnit\Framework\Attributes\Test;
 use TarfinLabs\Netgsm\Exceptions\NetgsmException;
 use TarfinLabs\Netgsm\Netgsm;
 
@@ -45,9 +46,7 @@ class NetgsmAvailablePackagesTest extends BaseTestCase
             ));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_get_available_package_amounts_with_correct_arguments()
     {
         $response = '1000 | Adet Flash Sms | <BR>953 | Adet OTP Sms | <BR>643 | Adet | SMS<BR>';
@@ -64,9 +63,7 @@ class NetgsmAvailablePackagesTest extends BaseTestCase
         $this->assertSame($response[2]['amountType'], 'Adet');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function should_throw_exception_when_return_code_is_not_success()
     {
         $errorCode = $this->faker->randomElement([30, 40, 100]);


### PR DESCRIPTION
- Laravel 12 support added.
- PHP 8.4 support added.
- Laravel 10 and below versions are no longer supported.
- PHP 8.2 and below versions are no longer supported.