### PR TITLE
feat: add Laravel 13 and PHP 8.5 support (v5.2.0)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,11 @@ jobs:
             fail-fast: true
             matrix:
                 php: [8.2, 8.3, 8.4]
-                laravel: [11, 12]
+                laravel: [11, 12, 13]
                 stability: [prefer-lowest, prefer-stable]
+                exclude:
+                    - php: 8.2
+                      laravel: 13
 
         name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Stability ${{ matrix.stability }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php: [8.2, 8.3, 8.4]
+                php: [8.2, 8.3, 8.4, 8.5]
                 laravel: [11, 12, 13]
                 stability: [prefer-lowest, prefer-stable]
                 exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `netgsm` will be documented in this file
 
 ## Unreleased
 
+## [6.0.0] - 2026-04-02
+- Laravel 13 support added.
+
 ## [5.0.0] - 2025-02-20
 - Laravel 12 support added.
 - PHP 8.4 support added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to `netgsm` will be documented in this file
 
 ## [5.1.0] - 2026-04-02
 - Laravel 13 support added.
+- PHP 8.5 support added.
 
 ## [5.0.0] - 2025-02-20
 - Laravel 12 support added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `netgsm` will be documented in this file
 
 ## Unreleased
 
-## [6.0.0] - 2026-04-02
+## [5.1.0] - 2026-04-02
 - Laravel 13 support added.
 
 ## [5.0.0] - 2025-02-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to `netgsm` will be documented in this file
 
 ## Unreleased
 
-## [5.1.0] - 2026-04-02
+## [5.2.0] - 2026-04-08
 - Laravel 13 support added.
 - PHP 8.5 support added.
+
+## [5.1.0] - 2025-11-24
+- Fix OTP XML message response parsing (#48 by @oguzhankrcb)
 
 ## [5.0.0] - 2025-02-20
 - Laravel 12 support added.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Total Downloads](https://img.shields.io/packagist/dt/tarfin-labs/netgsm.svg?style=flat-square)](https://packagist.org/packages/tarfin-labs/netgsm)
 
 ## Introduction
-With this package, you can send easily [Netgsm notifications](https://www.netgsm.com.tr/dokuman/#api-dok%C3%BCman%C4%B1) with Laravel `^8.0`.
+With this package, you can send easily [Netgsm notifications](https://www.netgsm.com.tr/dokuman/#api-dok%C3%BCman%C4%B1) with Laravel `^11.0`.
 This package also provides some simple reporting.
 
 > This package requires PHP `8.2` or higher and Laravel `11.0` or higher.   

--- a/composer.json
+++ b/composer.json
@@ -33,17 +33,17 @@
     "require": {
         "php": "^8.2|^8.3|^8.4",
         "guzzlehttp/guzzle": "^7.1",
-        "illuminate/support": "^11.0|^12.0",
-        "illuminate/notifications": "^11.0|^12.0",
-        "illuminate/translation": "^11.0|^12.0",
+        "illuminate/support": "^11.0|^12.0|^13.0",
+        "illuminate/notifications": "^11.0|^12.0|^13.0",
+        "illuminate/translation": "^11.0|^12.0|^13.0",
         "nesbot/carbon": "^3.8.5",
         "ext-simplexml": "*"
     },
     "require-dev": {
         "fakerphp/faker": "^1.14",
-        "phpunit/phpunit": "^10.0|^11.0",
-        "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^9.0|^10.0"
+        "phpunit/phpunit": "^10.0|^11.0|^12.0|^13.0",
+        "mockery/mockery": "^1.6",
+        "orchestra/testbench": "^9.0|^10.0|^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     ],
     "require": {
-        "php": "^8.2|^8.3|^8.4",
+        "php": "^8.2|^8.3|^8.4|^8.5",
         "guzzlehttp/guzzle": "^7.1",
         "illuminate/support": "^11.0|^12.0|^13.0",
         "illuminate/notifications": "^11.0|^12.0|^13.0",


### PR DESCRIPTION
## Summary

  - Add `^13.0` constraint to `illuminate/support`, `illuminate/notifications`, and `illuminate/translation`
  - Update `orchestra/testbench` to `^11.0` and `phpunit/phpunit` to `^12.0|^13.0`
  - Bump `mockery/mockery` to `^1.6` (required by testbench 11)
  - Add `^8.5` to PHP version constraint
  - Exclude PHP 8.2 + Laravel 13 combination from CI matrix (Laravel 13 requires PHP 8.3+)

  ## Notes

  - Backward compatibility with Laravel 11 and 12 is preserved
  - No source code changes required — Laravel 13 has no breaking changes affecting this package
  - This release is tagged as `v5.2.0` — additive change, no breaking changes

  ## Test Plan

  - [x] `composer update` resolves successfully against Laravel 13
  - [x] CI matrix passes for PHP 8.3 + Laravel 13 and PHP 8.4 + Laravel 13
  - [x] CI matrix correctly skips PHP 8.2 + Laravel 13 combination
  - [x] CI matrix passes for PHP 8.5 across all Laravel versions
  - [x] Existing tests pass without modification