### PR TITLE
fix: omit credential query params for Netgsm XML POST requests

### DIFF
--- a/src/NetgsmApiClient.php
+++ b/src/NetgsmApiClient.php
@@ -64,6 +64,8 @@ class NetgsmApiClient
                 $options['form_params'] = $params;
             } else {
                 $options['body'] = $params;
+                // remove query parameters for POST requests with raw body
+                unset($options['query']);
             }
         }
 


### PR DESCRIPTION
XML payloads already include usercode and password. Remove the default query string for POST requests that use a raw body instead of form_params.
